### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
   "main": "index.js",
   "codeVersions": [
     {
+      "code": "1.66.0",
+      "electron": "17.3.0",
+      "modules": 101
+    },
+    {
       "code": "1.59.0",
       "electron": "13.1.7",
       "modules": 89


### PR DESCRIPTION
With release of VSCode 1.66 Pico-Go broke because of bindings issue

Release notes: https://code.visualstudio.com/updates/v1_66#_nodemoduleversion-and-nodejs-api-update