### PR TITLE
update to support later vscode versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
   "main": "index.js",
   "codeVersions": [
     {
+      "code": "1.66.2",
+      "electron": "17.2.0",
+      "modules": 101
+    },
+    {
       "code": "1.59.0",
       "electron": "13.1.7",
       "modules": 89
@@ -24,9 +29,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "electron-rebuild": "^2.3.5",
+    "electron-rebuild": "^3.2.7",
     "lodash": "^4.17.21",
-    "node-abi": "^2.30.0",
+    "node-abi": "^3.15.0",
     "semver": "^7.3.5",
     "serialport": "^9.2.0"
   }


### PR DESCRIPTION

Bump modules and the current vscode revision. 

Should help resolve https://github.com/cpwood/Pico-Go/issues/122 .

Rebuild the extension and confirmed working on win32 / vscode 1.66.2